### PR TITLE
DTSPO-30114 - Add new map for jenkins library

### DIFF
--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -102,3 +102,13 @@ npm:
   puppeteer:
     version: "19.0.0"
     date_deadline: "2025-03-28"
+acr:
+  old_registry_migration:
+    pattern: "hmctsprivate|hmctspublic|hmctssandbox|sdshmctspublic|sdshmctspublicsbox"
+    new_registries: "hmctsprod,hmctssbox"
+    date_deadline: "2026-04-15"
+jenkins:
+  library:
+    pattern: "master"
+    version: "2.0.0"
+    date_deadline: "2026-05-31"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -122,4 +122,4 @@ jenkins:
   library:
     pattern: "master|DTSPO-30114/library-nagger"
     version: "2.0.0"
-    date_deadline: "2026-12-31"
+    date_deadline: "2026-05-31"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -120,6 +120,6 @@ acr:
     date_deadline: "2026-04-15"
 jenkins:
   library:
-    pattern: "master"
+    pattern: "master|DTSPO-30114/library-nagger"
     version: "2.0.0"
-    date_deadline: "2026-05-31"
+    date_deadline: "2026-12-31"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -120,6 +120,6 @@ acr:
     date_deadline: "2026-04-15"
 jenkins:
   library:
-    pattern: "master|DTSPO-30114/library-nagger"
+    pattern: "DTSPO-30114/library-nagger"
     version: "2.0.0"
-    date_deadline: "2026-09-30"
+    date_deadline: "2026-08-31"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -120,6 +120,6 @@ acr:
     date_deadline: "2026-04-15"
 jenkins:
   library:
-    pattern: "master|DTSPO-30114/library-nagger"
+    pattern: "master"
     version: "2.0.0"
     date_deadline: "2026-05-31"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -122,4 +122,4 @@ jenkins:
   library:
     pattern: "master|DTSPO-30114/library-nagger"
     version: "2.0.0"
-    date_deadline: "2026-05-31"
+    date_deadline: "2026-10-31"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -122,4 +122,4 @@ jenkins:
   library:
     pattern: "master|DTSPO-30114/library-nagger"
     version: "2.0.0"
-    date_deadline: "2026-10-31"
+    date_deadline: "2026-09-30"

--- a/nagger-versions.yaml
+++ b/nagger-versions.yaml
@@ -120,6 +120,6 @@ acr:
     date_deadline: "2026-04-15"
 jenkins:
   library:
-    pattern: "master"
+    pattern: "master|DTSPO-30114/library-nagger"
     version: "2.0.0"
     date_deadline: "2026-05-31"


### PR DESCRIPTION
### Jira link

See [DTSPO-30114](https://tools.hmcts.net/jira/browse/DTSPO-30114)

### Change description

This is preparation for moving over the environment based agents. This will help us encourage teams to migrate over to the new pipeline structure over time.

See https://github.com/hmcts/cnp-jenkins-library/pull/1457

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
